### PR TITLE
Changed UA

### DIFF
--- a/init.php
+++ b/init.php
@@ -39,7 +39,7 @@ class Tumblr_GDPR extends Plugin {
 			'url' => $url,
 			'login' => $login,
 			'pass' => $pass,
-			'useragent' => 'googlebot'
+			'useragent' => 'Mozilla/5.0 (compatible; Baiduspider; +http://www.baidu.com/search/spider.html)'
 		);
 
 		// II. call normal fetching method with the new UA


### PR DESCRIPTION
Tumblr blocked googlebot from accessing RSS freely, this fixes it

Thanks to Loewi on TT-RSS discourse ( see https://discourse.tt-rss.org/t/change-on-tumblr-rss-feeds-not-working/1158/120 )

Works as of 2018-10-15 @ 9:21pm (UTC)