### PR TITLE
Added renaming instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Plugin for [Tiny Tiny RSS](https://tt-rss.org/) to workaround GDPR in Europe.
 
 # INSTALLATION
-- Put the tumblr_gdpr into your plugins.local if you have (or plugins if not)
+- Download from [Releases](https://github.com/GregThib/ttrss-tumblr-gdpr/releases) or git clone
+- Rename the downloaded, extracted directory to `tumblr_gdpr`
+- Put the tumblr_gdpr into your plugins.local if you have (or plugins if not). The path to `init.php` should be this: `[TTRSS install dir]/plugins.local/tumblr_gdpr/init.php`
 - Activate it in the UI panel configurator, or by config.php for the whole instance
 - Optionnally add some domains hosted by Tumblr with another URI in : "prefs/config/Tumblr GDPR"


### PR DESCRIPTION
I added logological's solution to readme, I think it should be there as this breaks the installation.

https://github.com/GregThib/ttrss-tumblr-gdpr/issues/5#issuecomment-392243837